### PR TITLE
Audit README documentation and verify all links

### DIFF
--- a/asterix/storage/__init__.py
+++ b/asterix/storage/__init__.py
@@ -1,0 +1,11 @@
+"""
+Asterix Storage Module
+
+Provides state persistence backends for agent state management.
+"""
+
+from .agent_state import SQLiteStateBackend
+
+__all__ = [
+    "SQLiteStateBackend",
+]


### PR DESCRIPTION
- Add proper exports to asterix/storage/__init__.py
- Enables documented import: from asterix.storage import SQLiteStateBackend
- Fixes import path issue referenced in README.md line 462