### PR TITLE
Modularize README and create comprehensive documentation structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ uv.lock
 __pycache__/
 .env
 logs/
-docs/
 asterix_agent.egg-info/
 dist/
 agent_states/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Stateful AI agents with editable memory blocks and persistent storage.**
 
-> **Note:** Asterix is in Beta (v0.1.4). Core features are stable and production-ready. 
+> **Note:** Asterix is in Beta (v0.1.4). Core features are stable and production-ready.
 > Enhanced features and optimizations are in active development.
 
 Asterix is a lightweight Python library for building AI agents that can remember, learn, and persist their state across sessions. No servers required - just `pip install` and start building.
@@ -49,7 +49,7 @@ agent = Agent(
         "task": BlockConfig(size=1500, priority=1),
         "notes": BlockConfig(size=1000, priority=2)
     },
-    model="openai/gpt-5-mini"
+    model="openai/gpt-4o-mini"
 )
 
 # Chat with your agent
@@ -72,123 +72,6 @@ def read_file(filepath: str) -> str:
 response = agent.chat("Read config.yaml and summarize the settings")
 ```
 
-## Advanced Tool Features
-
-### Parameter Validation
-
-Tools can define validation constraints for their parameters:
-```python
-from asterix.tools.base import Tool, ParameterConstraint
-
-@agent.tool(
-    name="create_user",
-    description="Create a new user account",
-    constraints={
-        "username": ParameterConstraint(
-            min_length=3,
-            max_length=20,
-            pattern=r'^[a-zA-Z0-9_]+$'
-        ),
-        "age": ParameterConstraint(
-            min_value=13,
-            max_value=120
-        )
-    }
-)
-def create_user(username: str, age: int) -> str:
-    return f"Created user {username}, age {age}"
-```
-
-### Tool Categories
-
-Organize tools by category for better discovery:
-```python
-from asterix.tools.base import ToolCategory
-
-# Tools are automatically categorized
-memory_tools = agent._tool_registry.get_by_category(ToolCategory.MEMORY)
-file_tools = agent._tool_registry.get_by_category(ToolCategory.FILE_OPS)
-
-# List all categories with counts
-categories = agent._tool_registry.list_categories()
-print(categories)  # {"memory": 5, "file_operations": 3, "custom": 2}
-```
-
-### Retry Logic
-
-Enable automatic retries for transient failures:
-```python
-from asterix.tools.base import Tool
-
-@agent.tool(
-    name="fetch_data",
-    description="Fetch data from API",
-    retry_on_error=True,
-    max_retries=3
-)
-def fetch_data(url: str) -> str:
-    # Will retry up to 3 times with exponential backoff
-    response = requests.get(url)
-    return response.text
-```
-
-### Error Handling
-
-Rich error context and helpful suggestions:
-```python
-# Automatic error suggestions
-try:
-    agent.get_tool("read_fil")  # Typo!
-except ToolNotFoundError as e:
-    print(e)  # "Tool 'read_fil' not found. Did you mean: read_file?"
-```
-
-### Auto-Documentation
-
-Generate documentation for your tools:
-```python
-# Single tool documentation
-docs = agent._tool_registry.generate_tool_docs("read_file", format="markdown")
-print(docs)
-
-# Complete registry documentation
-full_docs = agent._tool_registry.generate_registry_docs(
-    format="markdown",
-    group_by_category=True
-)
-
-# Save to file
-with open("TOOL_REFERENCE.md", "w") as f:
-    f.write(full_docs)
-
-# Export as JSON catalog
-catalog = agent._tool_registry.export_tool_catalog("json")
-
-# Quick reference guide
-quick_ref = agent._tool_registry.generate_quick_reference()
-```
-
-### Tool Discovery
-
-Find tools by various criteria:
-```python
-# Filter by category
-memory_tools = agent._tool_registry.filter_tools(category=ToolCategory.MEMORY)
-
-# Filter by name pattern
-search_tools = agent._tool_registry.filter_tools(name_pattern="search")
-
-# Filter by capabilities
-validated_tools = agent._tool_registry.filter_tools(has_validation=True)
-retry_tools = agent._tool_registry.filter_tools(has_retry=True)
-
-# Get detailed tool info
-info = agent._tool_registry.get_tool_info("core_memory_append")
-print(f"Category: {info['category']}")
-print(f"Constraints: {info['constraints']}")
-print(f"Examples: {info['examples']}")
-```
-
 ### Save & Load State
 
 ```python
@@ -200,535 +83,57 @@ agent = Agent.load_state("agent_id")
 agent.chat("What were we discussing?")  # Remembers everything!
 ```
 
-## Logging
+---
 
-Asterix uses Python's standard logging module. By default, logs are not displayed. To enable logging:
+## 📚 Documentation
 
-### Console Logging
-```python
-import logging
+Comprehensive documentation is available in the [`docs/`](docs/) directory:
 
-# Show all logs
-logging.basicConfig(level=logging.INFO)
+### Core Concepts
+- **[Memory System](docs/memory-system.md)** - How agent memory works (blocks, archival, conversation search)
+- **[Tool System](docs/tool-system.md)** - Creating and using tools (validation, categories, retry logic)
+- **[Storage Backends](docs/storage-backends.md)** - State persistence (JSON, SQLite, custom backends)
+- **[Configuration](docs/configuration.md)** - Environment variables, YAML, and Python configuration
 
-# Or just show errors
-logging.basicConfig(level=logging.ERROR)
-```
+### Guides
+- **[Examples Guide](docs/examples-guide.md)** - Walkthrough of all examples with explanations
+- **[API Reference](docs/api-reference.md)** - Complete API documentation
 
-### File Logging
-```python
-import logging
-
-logging.basicConfig(
-    level=logging.DEBUG,
-    filename='asterix.log',
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
-```
-
-### Fine-grained Control
-```python
-import logging
-
-# Control specific modules
-logging.getLogger('asterix.agent').setLevel(logging.DEBUG)
-logging.getLogger('asterix.core').setLevel(logging.WARNING)
-```
+### Quick Links
+- [Environment Setup](docs/configuration.md#environment-variables)
+- [YAML Configuration Template](example_agent_config.yaml)
+- [Built-in Memory Tools](docs/memory-system.md#built-in-memory-tools)
+- [Custom Tool Development](docs/tool-system.md#advanced-tool-development)
+- [JSON vs SQLite Backends](docs/storage-backends.md#choosing-a-backend)
 
 ---
 
-## Configuration
+## 📦 Examples
 
-### Environment Variables
-
-Create a `.env` file in your project root:
+Complete working examples in [`examples/`](examples/):
 
 ```bash
-# LLM Provider (at least one required)
-GROQ_API_KEY=your-groq-api-key
-OPENAI_API_KEY=your-openai-api-key
-
-# Vector Storage (required)
-QDRANT_URL=https://your-cluster.cloud.qdrant.io:6333
-QDRANT_API_KEY=your-qdrant-api-key
-
-# Optional
-ASTERIX_STATE_DIR=./agent_states
-ASTERIX_LOG_LEVEL=INFO
-```
-
-### YAML Configuration (Optional)
-
-```yaml
-# agent_config.yaml
-agent_id: "my_agent"
-max_heartbeat_steps: 10
-
-# LLM Configuration
-llm:
-  provider: "openai"
-  model: "gpt-5-mini"
-  temperature: 0.1
-  max_tokens: 1000
-
-# Memory Blocks
-blocks:
-  task:
-    size: 1500
-    priority: 1
-    description: "Current task and progress"
-  
-  notes:
-    size: 1000
-    priority: 2
-    description: "Important notes and reminders"
-
-# Storage
-storage:
-  qdrant_url: "${QDRANT_URL}"
-  qdrant_api_key: "${QDRANT_API_KEY}"
-  state_backend: "json"
-  state_dir: "./agent_states"
-
-# Memory Management
-memory:
-  eviction_strategy: "summarize_and_archive"
-  context_window_threshold: 0.85
-
-# Embeddings
-embedding:
-  provider: "openai"
-  model: "text-embedding-3-small"
-  dimensions: 1536
-```
-
-Load from YAML:
-```python
-agent = Agent.from_yaml("agent_config.yaml")
-```
-
-### Tool Configuration
-
-Configure tool behavior when registering:
-```python
-from asterix.tools.base import Tool, ToolCategory, ParameterConstraint
-
-@agent.tool(
-    name="advanced_tool",
-    description="Tool with full configuration",
-    category=ToolCategory.DATA,
-    constraints={
-        "query": ParameterConstraint(min_length=1, max_length=500)
-    },
-    examples=[
-        "advanced_tool(query='search term')",
-        "advanced_tool(query='another example')"
-    ],
-    retry_on_error=True,
-    max_retries=3
-)
-def advanced_tool(query: str) -> str:
-    return f"Processed: {query}"
-```
-
----
-
-## Memory System
-
-### Built-in Memory Tools
-
-Agents have 5 built-in tools for managing their memory:
-
-1. **`core_memory_append`** - Add content to a memory block
-2. **`core_memory_replace`** - Replace content in a memory block
-3. **`archival_memory_insert`** - Store information in Qdrant for long-term retrieval
-4. **`archival_memory_search`** - Search archived memories semantically
-5. **`conversation_search`** - Search conversation history
-
-These tools are called automatically by the agent when needed.
-
-### Memory Blocks
-
-Configure memory blocks with custom sizes and priorities:
-
-```python
-blocks = {
-    "task": BlockConfig(
-        size=2000,          # Max tokens before eviction
-        priority=1,         # Lower = evicted first
-        description="Current task context"
-    ),
-    "user_prefs": BlockConfig(
-        size=500,
-        priority=5,         # High priority = rarely evicted
-        description="User preferences and settings"
-    )
-}
-```
-
-### Automatic Memory Management
-
-When a block exceeds its token limit:
-1. Content is summarized by LLM
-2. Full content archived in Qdrant
-3. Block replaced with summary
-4. Original retrievable via semantic search
-
----
-
-## Custom Tools
-
-Register custom tools using the decorator pattern:
-
-```python
-from asterix import Agent
-
-agent = Agent(...)
-
-@agent.tool(
-    name="execute_shell",
-    description="Run a shell command and return output"
-)
-def execute_shell(command: str) -> str:
-    import subprocess
-    result = subprocess.run(command, shell=True, capture_output=True, text=True)
-    return result.stdout
-
-@agent.tool(name="search_web")
-def search_web(query: str) -> str:
-    # Your web search implementation
-    return "Search results..."
-
-# Agent can now use these tools
-response = agent.chat("List all Python files in the current directory")
-```
-
-### Tool Development
-
-Creating custom tools with full features:
-```python
-from asterix.tools.base import Tool, ToolCategory, ParameterConstraint
-
-class MyCustomTool(Tool):
-    def __init__(self):
-        super().__init__(
-            name="my_tool",
-            description="Custom tool with validation",
-            func=self.execute,
-            category=ToolCategory.CUSTOM,
-            constraints={
-                "param": ParameterConstraint(min_length=5)
-            },
-            retry_on_error=True,
-            max_retries=2
-        )
-    
-    def execute(self, param: str) -> str:
-        # Your tool logic here
-        return f"Processed: {param}"
-
-# Register with agent
-agent.register_tool(MyCustomTool())
-```
-
----
-
-## State Persistence
-
-Asterix supports persistent agent state across sessions using two built-in backends: **JSON** (default, simple) and **SQLite** (better for multiple agents).
-
-### JSON Backend (Default)
-
-Perfect for single agents, prototyping, and human-readable storage:
-
-```python
-from asterix import Agent, BlockConfig
-
-# Create agent (JSON backend is default)
-agent = Agent(
-    agent_id="my_assistant",
-    blocks={
-        "user_prefs": BlockConfig(size=800, priority=5),
-        "notes": BlockConfig(size=1200, priority=3)
-    },
-    model="openai/gpt-4o-mini"
-)
-
-# Chat with agent
-agent.chat("Hi! I prefer Python over JavaScript.")
-
-# Save state to ./agent_states/my_assistant.json
-agent.save_state()
-
-# Later session - load previous state
-agent = Agent.load_state("my_assistant")
-agent.chat("What language do I prefer?")  # Remembers everything!
-```
-
-### SQLite Backend
-Better for production, multiple agents, and querying capabilities:
- 
-```python
-from asterix import Agent, BlockConfig, StorageConfig
-
-# Create agent with SQLite backend
-agent = Agent(
-    agent_id="production_agent",
-    blocks={"task": BlockConfig(size=2000, priority=1)},
-    model="openai/gpt-4o-mini",
-    storage=StorageConfig(
-        state_backend="sqlite",
-        state_db="./agent_states/agents.db"
-    )
-)
-
-# Save to SQLite database
-agent.save_state()
-
-# Load from SQLite
-agent = Agent.load_state(
-    "production_agent",
-    state_backend="sqlite",
-    state_db="./agent_states/agents.db"
-)
-```
-
-### SQLite Advanced Features
-Query agent metadata without loading full state:
-
-```python
-from asterix.storage import SQLiteStateBackend
-
-backend = SQLiteStateBackend("./agent_states/agents.db")
-
-# List all agents
-agents = backend.list_agents()
-print(agents)  # ['agent1', 'agent2', 'agent3']
- 
-# Get agent metadata
-info = backend.get_agent_info("agent1")
-print(info)
-
-# {
-#   'agent_id': 'agent1',
-#   'model': 'openai/gpt-4o-mini',
-#   'block_count': 3,
-#   'message_count': 42,
-#   'created_at': '2025-01-15T10:30:00',
-#   'last_updated': '2025-01-15T14:25:00'
-# }
-
-# List all agents with metadata
-
-all_agents = backend.list_all_info(limit=10)
-```
-
-### Choosing a Backend
-
-| Feature | JSON | SQLite |
-|---------|------|--------|
-| **Best for** | 1-10 agents, prototyping | 10+ agents, production |
-| **Performance** | Fast for single agent | Fast for many agents |
-| **Querying** | ❌ | ✅ |
-| **Human-readable** | ✅ | ❌ |
-| **Atomic updates** | ❌ | ✅ |
-| **File structure** | One file per agent | Single database file |
-
-### Custom Backend
-
-Implement your own storage backend:
-
-```python
-class RedisBackend:
-    def save(self, agent_id: str, state_dict: dict) -> None:
-        """Save agent state"""
-        pass
-
-    def load(self, agent_id: str) -> dict:
-        """Load agent state"""
-        pass
-
-    def exists(self, agent_id: str) -> bool:
-        """Check if agent exists"""
-        pass
-
-# Use custom backend
-agent = Agent(..., storage=StorageConfig(state_backend=RedisBackend()))
-```
-
-## Error Handling
-
-Asterix provides detailed error messages with context and suggestions:
-
-### Tool Errors
-```python
-from asterix.tools.base import ToolNotFoundError, ToolExecutionError, ToolValidationError
-
-try:
-    # Typo in tool name
-    agent._tool_registry.execute_tool("read_fle", filepath="test.txt")
-except ToolNotFoundError as e:
-    print(e)  # Suggests similar tool names
-    
-try:
-    # Invalid parameter
-    agent._tool_registry.execute_tool("create_user", username="ab", age=5)
-except ToolValidationError as e:
-    print(e)  # Shows validation constraints and provided value
-```
-
-### Validation Errors
-```python
-# Parameter validation errors include helpful context
-# "Tool 'create_user' parameter 'username' validation failed: 
-#  username length must be >= 3, got 2
-#  Provided value: ab"
-```
-
-### Error Context
-
-All tool errors include rich metadata for debugging:
-```python
-try:
-    result = tool.execute(invalid_param="value")
-except Exception as e:
-    # Error metadata includes:
-    # - Tool name
-    # - Exception type
-    # - Parameters provided
-    # - Retry attempts (if applicable)
-    # - Full stack trace in logs
-    pass
-```
-
----
-
-## Examples
-
-For complete working examples, see the [`examples/`](examples/) directory:
-
-- **[`basic_chat.py`](examples/basic_chat.py)** - Simple conversation agent
-- **[`custom_tools.py`](examples/custom_tools.py)** - Tool registration with validation and constraints
-- **[`persistent_agent.py`](examples/persistent_agent.py)** - State persistence with JSON backend (default)
-- **[`persistent_agent_sqlite.py`](examples/persistent_agent_sqlite.py)** - State persistence with SQLite backend for production use
-- **[`tool_documentation.py`](examples/tool_documentation.py)** - Auto-documentation generation for tools
-- **[`cli_agent.py`](examples/cli_agent.py)** - Full-featured CLI agent with file operations
-- **[`yaml_config.py`](examples/yaml_config.py)** - YAML configuration example
-
-### Running the Examples
-
-```bash
-# Clone the repository
+# Clone and setup
 git clone https://github.com/adityasarade/Asterix.git
-cd Asterix
-# Install in editable mode
-pip install -e .
-
-# Set up environment variables (create .env file)
-# OPENAI_API_KEY=your-key
-# QDRANT_URL=your-qdrant-url
-# QDRANT_API_KEY=your-qdrant-key
+cd Asterix && pip install -e .
 
 # Run examples
-python examples/basic_chat.py
-python examples/persistent_agent.py
-python examples/persistent_agent_sqlite.py
+python examples/basic_chat.py              # Simple conversation
+python examples/custom_tools.py            # Tool registration
+python examples/persistent_agent.py        # JSON persistence
+python examples/persistent_agent_sqlite.py # SQLite persistence
+python examples/cli_agent.py               # Full-featured CLI
 ```
 
-### CLI Agent with File Operations
-
-```python
-from asterix import Agent, BlockConfig
-import os
-
-agent = Agent(
-    blocks={
-        "current_task": BlockConfig(size=2000, priority=1),
-        "file_context": BlockConfig(size=3000, priority=2)
-    },
-    model="openai/gpt-5-mini"
-)
-
-@agent.tool(name="list_files")
-def list_files(directory: str = ".") -> str:
-    files = os.listdir(directory)
-    return "\n".join(files)
-
-@agent.tool(name="read_file")
-def read_file(filepath: str) -> str:
-    with open(filepath, 'r') as f:
-        return f.read()
-
-# Use the agent
-agent.chat("List all Python files and review main.py for potential issues")
-```
-
-### Multi-Agent System
-
-```python
-# Orchestrator agent
-main_agent = Agent(
-    agent_id="orchestrator",
-    blocks={"plan": BlockConfig(size=1500)},
-    model="openai/gpt-5-mini"
-)
-
-# Specialized agents
-code_reviewer = Agent(
-    agent_id="reviewer",
-    blocks={"code": BlockConfig(size=3000)},
-    model="openai/gpt-5-mini"
-)
-
-# Coordination
-task = "Review auth.py for security issues"
-plan = main_agent.chat(f"Break down: {task}")
-review = code_reviewer.chat(f"Execute: {plan}")
-summary = main_agent.chat(f"Summarize: {review}")
-```
-
----
-
-## Advanced Usage
-
-### Direct Memory Access
-
-```python
-# Get all memory blocks
-memory = agent.get_memory()
-print(memory["task"])
-
-# Update memory manually
-agent.update_memory("task", "New content")
-
-# Archival memory search is handled automatically by the agent
-# when it needs to retrieve information. The agent will use the
-# archival_memory_search tool internally when needed.
-
-# To manually search, you can access the tool:
-tool_result = agent._tool_registry.execute_tool(
-    "archival_memory_search",
-    query="user preferences",
-    k=5
-)
-```
+See the **[Examples Guide](docs/examples-guide.md)** for detailed walkthroughs.
 
 ---
 
 ## 🧪 Testing
 
 ```bash
-# Install dev dependencies
 pip install -e ".[dev]"
-
-# Run tests
-pytest
-
-# With coverage
 pytest --cov=asterix --cov-report=html
-
-# Run specific test
-pytest tests/test_agent.py::test_memory_tools
 ```
 
 ---
@@ -740,57 +145,15 @@ pytest tests/test_agent.py::test_memory_tools
 **Roadmap:**
 - [x] Core agent implementation
 - [x] Memory tools system
-- [x] State persistence
+- [x] State persistence (JSON & SQLite)
 - [x] Qdrant integration
-- [x] Enhanced tool registration (parameter validation, categories, retry logic)
-- [x] Auto-documentation system
+- [x] Enhanced tool system with validation
+- [x] Auto-documentation
 - [ ] Performance optimizations
-- [ ] Advanced monitoring and observability
+- [ ] Advanced monitoring
 - [ ] Streaming responses
 - [ ] Multi-agent collaboration
-- [ ] Custom memory backends (Redis, PostgreSQL)
-
-## Tool Reference
-
-### Built-in Memory Tools
-
-Asterix provides 5 built-in tools for memory management:
-
-| Tool | Category | Description |
-|------|----------|-------------|
-| `core_memory_append` | memory | Add content to a memory block |
-| `core_memory_replace` | memory | Replace content in a memory block |
-| `archival_memory_insert` | memory | Store information in long-term memory (Qdrant) |
-| `archival_memory_search` | memory | Search long-term memory |
-| `conversation_search` | memory | Search conversation history |
-
-### Tool System Features
-
-- **Automatic Schema Generation** - Type hints → OpenAI function schemas
-- **Parameter Validation** - Min/max values, lengths, patterns, allowed values
-- **Category Organization** - Group tools by purpose (memory, file_ops, web, etc.)
-- **Retry Logic** - Automatic retries with exponential backoff
-- **Error Recovery** - Smart error messages with hints and suggestions
-- **Auto-Documentation** - Generate markdown/JSON/YAML docs from metadata
-- **Tool Discovery** - Filter and search tools by name, category, capabilities
-
-### Generate Documentation
-```bash
-# In Python
-from asterix import Agent
-
-agent = Agent()
-
-# Generate tool reference
-docs = agent._tool_registry.generate_registry_docs(format="markdown")
-with open("TOOL_REFERENCE.md", "w") as f:
-    f.write(docs)
-
-# Export tool catalog
-catalog = agent._tool_registry.export_tool_catalog("json")
-with open("tool_catalog.json", "w") as f:
-    f.write(catalog)
-```
+- [ ] Additional backends (Redis, PostgreSQL)
 
 ---
 
@@ -822,9 +185,11 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Support
 
-- **Issues:** [GitHub Issues](https://github.com/adityasarade/Asterix/issues)
-- **Discussions:** [GitHub Discussions](https://github.com/adityasarade/Asterix/discussions)
-- **Documentation:** [Full Docs](https://github.com/adityasarade/Asterix#readme)
+- **Documentation:** [Full documentation](docs/) with guides and API reference
+- **Issues:** [GitHub Issues](https://github.com/adityasarade/Asterix/issues) - Report bugs or request features
+- **Discussions:** [GitHub Discussions](https://github.com/adityasarade/Asterix/discussions) - Ask questions and share ideas
+- **Examples:** [Examples directory](examples/) - Working code examples
+- **Changelog:** [CHANGELOG.md](CHANGELOG.md) - Version history and updates
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,579 @@
+# API Reference
+
+Complete reference for Asterix classes, methods, and built-in tools.
+
+## Table of Contents
+
+- [Agent Class](#agent-class)
+- [Configuration Classes](#configuration-classes)
+- [Built-in Memory Tools](#built-in-memory-tools)
+- [Tool Registry](#tool-registry)
+- [Storage Backends](#storage-backends)
+- [Exceptions](#exceptions)
+
+---
+
+## Agent Class
+
+### `Agent`
+
+Main agent class for creating stateful AI agents.
+
+```python
+from asterix import Agent, BlockConfig, StorageConfig, MemoryConfig
+
+agent = Agent(
+    agent_id="my_agent",
+    model="openai/gpt-4o-mini",
+    temperature=0.7,
+    max_tokens=1000,
+    max_heartbeat_steps=10,
+    blocks={"task": BlockConfig(size=1500, priority=1)},
+    storage=StorageConfig(...),
+    memory_config=MemoryConfig(...)
+)
+```
+
+#### Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `agent_id` | `str` | Generated | Unique identifier for the agent |
+| `model` | `str` | Required | LLM model (e.g., "openai/gpt-4o-mini") |
+| `temperature` | `float` | `0.7` | Sampling temperature (0.0-2.0) |
+| `max_tokens` | `int` | `1000` | Maximum tokens per completion |
+| `max_heartbeat_steps` | `int` | `10` | Max tool call steps per turn |
+| `blocks` | `dict[str, BlockConfig]` | `{}` | Memory block configuration |
+| `storage` | `StorageConfig` | Default | Storage configuration |
+| `memory_config` | `MemoryConfig` | Default | Memory management configuration |
+
+#### Methods
+
+##### `chat(message: str) -> str`
+
+Send a message to the agent and get a response.
+
+```python
+response = agent.chat("Hello! Remember that I prefer Python.")
+print(response)
+```
+
+**Parameters:**
+- `message` (str): User message
+
+**Returns:**
+- `str`: Agent's response
+
+---
+
+##### `save_state(filepath: str = None) -> None`
+
+Save agent state to persistent storage.
+
+```python
+# Save using configured backend
+agent.save_state()
+
+# Save to specific file (JSON only)
+agent.save_state(filepath="./backups/agent.json")
+```
+
+**Parameters:**
+- `filepath` (str, optional): Custom file path (JSON backend only)
+
+---
+
+##### `load_state(agent_id: str, **kwargs) -> Agent` (classmethod)
+
+Load agent from persistent storage.
+
+```python
+# Load from default backend
+agent = Agent.load_state("my_agent")
+
+# Load from SQLite
+agent = Agent.load_state(
+    "my_agent",
+    state_backend="sqlite",
+    state_db="./agent_states/agents.db"
+)
+```
+
+**Parameters:**
+- `agent_id` (str): Agent identifier
+- `**kwargs`: Backend-specific parameters
+
+**Returns:**
+- `Agent`: Loaded agent instance
+
+---
+
+##### `from_yaml(config_path: str) -> Agent` (classmethod)
+
+Create agent from YAML configuration file.
+
+```python
+agent = Agent.from_yaml("agent_config.yaml")
+```
+
+**Parameters:**
+- `config_path` (str): Path to YAML config file
+
+**Returns:**
+- `Agent`: Configured agent instance
+
+---
+
+##### `tool(name: str, description: str, **kwargs)` (decorator)
+
+Register a custom tool with the agent.
+
+```python
+@agent.tool(name="read_file", description="Read a file")
+def read_file(filepath: str) -> str:
+    with open(filepath, 'r') as f:
+        return f.read()
+```
+
+**Parameters:**
+- `name` (str): Tool name
+- `description` (str): Tool description
+- `category` (ToolCategory, optional): Tool category
+- `constraints` (dict, optional): Parameter constraints
+- `examples` (list, optional): Usage examples
+- `retry_on_error` (bool, optional): Enable retry logic
+- `max_retries` (int, optional): Maximum retry attempts
+
+---
+
+##### `get_memory() -> dict[str, str]`
+
+Get all memory block contents.
+
+```python
+memory = agent.get_memory()
+print(memory["task"])
+print(memory["notes"])
+```
+
+**Returns:**
+- `dict[str, str]`: Dictionary of block names to contents
+
+---
+
+##### `update_memory(block: str, content: str) -> None`
+
+Manually update a memory block.
+
+```python
+agent.update_memory("task", "New task content")
+```
+
+**Parameters:**
+- `block` (str): Block name
+- `content` (str): New content
+
+---
+
+## Configuration Classes
+
+### `BlockConfig`
+
+Configuration for a memory block.
+
+```python
+from asterix import BlockConfig
+
+block = BlockConfig(
+    size=1500,
+    priority=2,
+    description="Current task context",
+    initial_value=""
+)
+```
+
+**Parameters:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `size` | `int` | Required | Max tokens before eviction |
+| `priority` | `int` | Required | Eviction priority (higher = kept longer) |
+| `description` | `str` | `""` | Block description |
+| `initial_value` | `str` | `""` | Initial content |
+
+---
+
+### `StorageConfig`
+
+Configuration for storage backends.
+
+```python
+from asterix import StorageConfig
+
+storage = StorageConfig(
+    qdrant_url="https://cluster.cloud.qdrant.io:6333",
+    qdrant_api_key="your-api-key",
+    qdrant_collection_name="asterix_memory",
+    vector_size=1536,
+    state_backend="sqlite",
+    state_dir="./agent_states",
+    state_db="agents.db"
+)
+```
+
+**Parameters:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `qdrant_url` | `str` | From env | Qdrant Cloud URL |
+| `qdrant_api_key` | `str` | From env | Qdrant API key |
+| `qdrant_collection_name` | `str` | `"asterix_memory"` | Collection name |
+| `vector_size` | `int` | `1536` | Embedding dimensions |
+| `state_backend` | `str` | `"json"` | Backend type ("json" or "sqlite") |
+| `state_dir` | `str` | `"./agent_states"` | State directory |
+| `state_db` | `str` | `"agents.db"` | SQLite database filename |
+
+---
+
+### `MemoryConfig`
+
+Configuration for memory management.
+
+```python
+from asterix import MemoryConfig
+
+memory = MemoryConfig(
+    eviction_strategy="summarize_and_archive",
+    summary_token_limit=220,
+    context_window_threshold=0.85,
+    extraction_enabled=True,
+    retrieval_k=6,
+    score_threshold=0.7
+)
+```
+
+**Parameters:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `eviction_strategy` | `str` | `"summarize_and_archive"` | Eviction strategy |
+| `summary_token_limit` | `int` | `220` | Target summary size |
+| `context_window_threshold` | `float` | `0.85` | Extraction trigger |
+| `extraction_enabled` | `bool` | `True` | Enable fact extraction |
+| `retrieval_k` | `int` | `6` | Number of memories to retrieve |
+| `score_threshold` | `float` | `0.7` | Minimum similarity score |
+
+---
+
+## Built-in Memory Tools
+
+Asterix provides 5 built-in tools for memory management:
+
+### 1. `core_memory_append`
+
+Add content to a memory block.
+
+**Parameters:**
+- `block` (str): Block name (e.g., "task", "notes")
+- `content` (str): Content to append
+
+**Returns:**
+- `str`: Confirmation message
+
+**Example:**
+```python
+# Agent automatically calls this
+# core_memory_append(block="task", content="User prefers Python")
+```
+
+---
+
+### 2. `core_memory_replace`
+
+Replace content in a memory block.
+
+**Parameters:**
+- `block` (str): Block name
+- `old_content` (str): Content to replace
+- `new_content` (str): New content
+
+**Returns:**
+- `str`: Confirmation message
+
+**Example:**
+```python
+# Agent automatically calls this
+# core_memory_replace(
+#     block="task",
+#     old_content="User prefers Python",
+#     new_content="User prefers TypeScript"
+# )
+```
+
+---
+
+### 3. `archival_memory_insert`
+
+Store information in Qdrant for long-term retrieval.
+
+**Parameters:**
+- `content` (str): Content to archive
+
+**Returns:**
+- `str`: Confirmation message with vector ID
+
+**Example:**
+```python
+# Agent automatically calls this
+# archival_memory_insert(content="Project X uses PostgreSQL with 10M records")
+```
+
+---
+
+### 4. `archival_memory_search`
+
+Search archived memories semantically.
+
+**Parameters:**
+- `query` (str): Search query
+- `k` (int, optional): Number of results (default: 5)
+
+**Returns:**
+- `str`: Retrieved memories
+
+**Example:**
+```python
+# Agent automatically calls this
+# archival_memory_search(query="database details", k=5)
+```
+
+---
+
+### 5. `conversation_search`
+
+Search conversation history.
+
+**Parameters:**
+- `query` (str): Search query
+- `k` (int, optional): Number of results (default: 3)
+
+**Returns:**
+- `str`: Relevant conversation turns
+
+**Example:**
+```python
+# Agent automatically calls this
+# conversation_search(query="API key location", k=3)
+```
+
+---
+
+## Tool Registry
+
+### `ToolRegistry`
+
+Manages agent tools and provides discovery capabilities.
+
+#### Methods
+
+##### `execute_tool(name: str, **kwargs) -> str`
+
+Execute a tool by name.
+
+```python
+result = agent._tool_registry.execute_tool(
+    "archival_memory_search",
+    query="user preferences",
+    k=5
+)
+```
+
+---
+
+##### `get_by_category(category: ToolCategory) -> list[Tool]`
+
+Get tools by category.
+
+```python
+from asterix.tools.base import ToolCategory
+
+memory_tools = agent._tool_registry.get_by_category(ToolCategory.MEMORY)
+```
+
+---
+
+##### `list_categories() -> dict[str, int]`
+
+List all categories with tool counts.
+
+```python
+categories = agent._tool_registry.list_categories()
+# {"memory": 5, "file_operations": 3, "custom": 2}
+```
+
+---
+
+##### `generate_tool_docs(tool_name: str, format: str) -> str`
+
+Generate documentation for a single tool.
+
+```python
+docs = agent._tool_registry.generate_tool_docs("read_file", format="markdown")
+```
+
+---
+
+##### `generate_registry_docs(format: str, group_by_category: bool) -> str`
+
+Generate documentation for all tools.
+
+```python
+full_docs = agent._tool_registry.generate_registry_docs(
+    format="markdown",
+    group_by_category=True
+)
+```
+
+---
+
+##### `export_tool_catalog(format: str) -> str`
+
+Export tool catalog.
+
+```python
+catalog = agent._tool_registry.export_tool_catalog("json")
+```
+
+---
+
+## Storage Backends
+
+### `JSONStateBackend`
+
+JSON file-based storage backend.
+
+```python
+from asterix.storage import JSONStateBackend
+
+backend = JSONStateBackend(state_dir="./agent_states")
+backend.save("agent_id", state_dict)
+state = backend.load("agent_id")
+```
+
+---
+
+### `SQLiteStateBackend`
+
+SQLite database storage backend.
+
+```python
+from asterix.storage import SQLiteStateBackend
+
+backend = SQLiteStateBackend("./agent_states/agents.db")
+backend.save("agent_id", state_dict)
+state = backend.load("agent_id")
+
+# Query operations
+agents = backend.list_agents()
+info = backend.get_agent_info("agent_id")
+all_info = backend.list_all_info(limit=10)
+```
+
+#### Additional Methods
+
+##### `list_agents() -> list[str]`
+
+List all agent IDs.
+
+---
+
+##### `get_agent_info(agent_id: str) -> dict`
+
+Get agent metadata.
+
+**Returns:**
+```python
+{
+    'agent_id': 'agent1',
+    'model': 'openai/gpt-4o-mini',
+    'block_count': 3,
+    'message_count': 42,
+    'created_at': '2025-01-15T10:30:00',
+    'last_updated': '2025-01-15T14:25:00'
+}
+```
+
+---
+
+##### `list_all_info(limit: int) -> list[dict]`
+
+List all agents with metadata.
+
+---
+
+## Exceptions
+
+### `ToolNotFoundError`
+
+Raised when a tool is not found.
+
+```python
+from asterix.tools.base import ToolNotFoundError
+
+try:
+    agent._tool_registry.execute_tool("nonexistent_tool")
+except ToolNotFoundError as e:
+    print(e)  # Suggests similar tools
+```
+
+---
+
+### `ToolExecutionError`
+
+Raised when tool execution fails.
+
+```python
+from asterix.tools.base import ToolExecutionError
+
+try:
+    agent._tool_registry.execute_tool("read_file", filepath="missing.txt")
+except ToolExecutionError as e:
+    print(e)  # Includes error context
+```
+
+---
+
+### `ToolValidationError`
+
+Raised when parameter validation fails.
+
+```python
+from asterix.tools.base import ToolValidationError
+
+try:
+    agent._tool_registry.execute_tool("create_user", username="ab", age=5)
+except ToolValidationError as e:
+    print(e)  # Shows validation constraints
+```
+
+---
+
+## Tool Categories
+
+Available tool categories:
+
+```python
+from asterix.tools.base import ToolCategory
+
+ToolCategory.MEMORY         # Memory management
+ToolCategory.FILE_OPS       # File operations
+ToolCategory.WEB            # Web/API operations
+ToolCategory.DATA           # Data processing
+ToolCategory.CUSTOM         # User-defined tools
+```
+
+---
+
+## See Also
+
+- [Tool System](tool-system.md) - Tool usage and development
+- [Memory System](memory-system.md) - Memory management
+- [Storage Backends](storage-backends.md) - Persistence
+- [Configuration](configuration.md) - Configuration options

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,568 @@
+# Configuration
+
+Asterix agents can be configured using Python code, environment variables, or YAML files. Configuration options control the LLM, memory blocks, storage, embeddings, and more.
+
+## Table of Contents
+
+- [Configuration Methods](#configuration-methods)
+- [Environment Variables](#environment-variables)
+- [YAML Configuration](#yaml-configuration)
+- [Python Configuration](#python-configuration)
+- [LLM Configuration](#llm-configuration)
+- [Memory Block Configuration](#memory-block-configuration)
+- [Storage Configuration](#storage-configuration)
+- [Embedding Configuration](#embedding-configuration)
+- [Logging Configuration](#logging-configuration)
+
+---
+
+## Configuration Methods
+
+Asterix supports three configuration methods with the following priority order:
+
+**Priority:** Python overrides > Environment variables > YAML > Defaults
+
+```python
+# Method 1: Python (highest priority)
+agent = Agent(model="openai/gpt-4o-mini", temperature=0.7)
+
+# Method 2: Environment variables
+# AGENT_MODEL=openai/gpt-4o-mini
+# AGENT_TEMPERATURE=0.7
+
+# Method 3: YAML file
+agent = Agent.from_yaml("agent_config.yaml")
+```
+
+---
+
+## Environment Variables
+
+Create a `.env` file in your project root:
+
+```bash
+# LLM Provider (at least one required)
+GROQ_API_KEY=your-groq-api-key
+OPENAI_API_KEY=your-openai-api-key
+
+# Vector Storage (required for archival memory)
+QDRANT_URL=https://your-cluster.cloud.qdrant.io:6333
+QDRANT_API_KEY=your-qdrant-api-key
+QDRANT_COLLECTION_NAME=asterix_memory  # Optional
+
+# Optional Settings
+ASTERIX_STATE_DIR=./agent_states
+ASTERIX_LOG_LEVEL=INFO
+AGENT_MODEL=openai/gpt-4o-mini
+AGENT_TEMPERATURE=0.1
+```
+
+### Available Environment Variables
+
+#### LLM Settings
+- `AGENT_MODEL` - Model to use (e.g., "openai/gpt-4o-mini")
+- `AGENT_TEMPERATURE` - Sampling temperature (0.0-2.0)
+- `AGENT_MAX_TOKENS` - Max tokens per completion
+- `LLM_TIMEOUT` - Request timeout in seconds
+- `GROQ_API_KEY` - Groq API key
+- `OPENAI_API_KEY` - OpenAI API key
+
+#### Storage Settings
+- `QDRANT_URL` - Qdrant Cloud URL
+- `QDRANT_API_KEY` - Qdrant API key
+- `QDRANT_COLLECTION_NAME` - Collection name (default: "asterix_memory")
+- `ASTERIX_STATE_DIR` - Directory for agent state files
+- `ASTERIX_STATE_BACKEND` - Backend type ("json" or "sqlite")
+- `ASTERIX_STATE_DB` - SQLite database filename
+
+#### Embedding Settings
+- `EMBED_PROVIDER` - Embedding provider ("openai" or "sentence-transformers")
+- `OPENAI_API_KEY` - Also used for embeddings
+
+#### Agent Settings
+- `AGENT_ID` - Agent identifier
+- `AGENT_MAX_HEARTBEAT_STEPS` - Max tool call steps (default: 10)
+- `ASTERIX_LOG_LEVEL` - Logging level (DEBUG, INFO, WARNING, ERROR)
+
+---
+
+## YAML Configuration
+
+For complex configurations, use a YAML file:
+
+```yaml
+# agent_config.yaml
+agent_id: "my_agent"
+max_heartbeat_steps: 10
+
+# LLM Configuration
+llm:
+  provider: "openai"
+  model: "gpt-4o-mini"
+  temperature: 0.1
+  max_tokens: 1000
+  timeout: 30
+
+# Memory Blocks
+blocks:
+  persona:
+    size: 1000
+    priority: 10
+    description: "Agent personality and behavior"
+    initial_value: "I am a helpful AI assistant."
+
+  user:
+    size: 1000
+    priority: 5
+    description: "User information"
+
+  task:
+    size: 1500
+    priority: 2
+    description: "Current task and context"
+
+  notes:
+    size: 800
+    priority: 3
+    description: "Important notes"
+
+# Storage
+storage:
+  qdrant_url: "${QDRANT_URL}"
+  qdrant_api_key: "${QDRANT_API_KEY}"
+  qdrant_collection_name: "asterix_memory"
+  vector_size: 1536
+  qdrant_timeout: 30
+  auto_create_collection: true
+
+  state_backend: "json"
+  state_dir: "./agent_states"
+
+# Memory Management
+memory:
+  eviction_strategy: "summarize_and_archive"
+  summary_token_limit: 220
+  context_window_threshold: 0.85
+  extraction_enabled: true
+  retrieval_k: 6
+  score_threshold: 0.7
+
+# Embeddings
+embedding:
+  provider: "openai"
+  model: "text-embedding-3-small"
+  dimensions: 1536
+  batch_size: 100
+```
+
+### Load from YAML
+
+```python
+from asterix import Agent
+
+agent = Agent.from_yaml("agent_config.yaml")
+```
+
+### Environment Variable Substitution
+
+YAML files support environment variable substitution using `${VAR_NAME}` syntax:
+
+```yaml
+storage:
+  qdrant_url: "${QDRANT_URL}"
+  qdrant_api_key: "${QDRANT_API_KEY}"
+```
+
+**See:** [example_agent_config.yaml](../example_agent_config.yaml) for a complete template with all options.
+
+---
+
+## Python Configuration
+
+Configure agents directly in Python:
+
+```python
+from asterix import Agent, BlockConfig, StorageConfig, MemoryConfig
+
+agent = Agent(
+    agent_id="my_agent",
+    model="openai/gpt-4o-mini",
+    temperature=0.7,
+    max_tokens=1000,
+
+    blocks={
+        "task": BlockConfig(size=1500, priority=1),
+        "notes": BlockConfig(size=1000, priority=2)
+    },
+
+    storage=StorageConfig(
+        state_backend="sqlite",
+        state_db="./agent_states/agents.db",
+        qdrant_url="https://your-cluster.cloud.qdrant.io:6333",
+        qdrant_api_key="your-api-key"
+    ),
+
+    memory_config=MemoryConfig(
+        eviction_strategy="summarize_and_archive",
+        context_window_threshold=0.85
+    )
+)
+```
+
+---
+
+## LLM Configuration
+
+### Supported Providers
+
+Asterix supports multiple LLM providers:
+
+- **OpenAI** - GPT-4, GPT-4o, GPT-3.5, etc.
+- **Groq** - Fast inference with Llama, Mixtral, etc.
+
+### Model Configuration
+
+```python
+# OpenAI models
+agent = Agent(model="openai/gpt-4o-mini")
+agent = Agent(model="openai/gpt-4o")
+agent = Agent(model="openai/gpt-3.5-turbo")
+
+# Groq models
+agent = Agent(model="groq/llama-3.1-70b-versatile")
+agent = Agent(model="groq/mixtral-8x7b-32768")
+```
+
+### Temperature and Tokens
+
+```python
+agent = Agent(
+    model="openai/gpt-4o-mini",
+    temperature=0.7,     # 0.0 = deterministic, 2.0 = very creative
+    max_tokens=1000,     # Maximum tokens per response
+    timeout=30           # Request timeout in seconds
+)
+```
+
+### YAML Format
+
+```yaml
+llm:
+  provider: "openai"
+  model: "gpt-4o-mini"
+  temperature: 0.1
+  max_tokens: 1000
+  timeout: 30
+
+# Legacy format also supported:
+# model: "openai/gpt-4o-mini"
+```
+
+---
+
+## Memory Block Configuration
+
+Memory blocks are editable sections of agent memory. Configure size, priority, and initial content.
+
+### Block Priority Guidelines
+
+- **Priority 10** - Critical (persona, core identity) - never evicted
+- **Priority 5-9** - Important (user preferences, key context) - rarely evicted
+- **Priority 2-4** - Normal (task context, notes) - evicted when needed
+- **Priority 1** - Low (temporary data) - evicted first
+
+### Python Configuration
+
+```python
+from asterix import Agent, BlockConfig
+
+agent = Agent(
+    blocks={
+        "persona": BlockConfig(
+            size=1000,
+            priority=10,
+            description="Agent personality",
+            initial_value="I am a helpful assistant."
+        ),
+        "user": BlockConfig(
+            size=1000,
+            priority=5,
+            description="User information"
+        ),
+        "task": BlockConfig(
+            size=1500,
+            priority=2,
+            description="Current task"
+        )
+    }
+)
+```
+
+### YAML Configuration
+
+```yaml
+blocks:
+  persona:
+    size: 1000
+    priority: 10
+    description: "Agent personality and behavior"
+    initial_value: "I am a helpful AI assistant."
+
+  user:
+    size: 1000
+    priority: 5
+    description: "Information about the user"
+
+  task:
+    size: 1500
+    priority: 2
+    description: "Current task and context"
+```
+
+---
+
+## Storage Configuration
+
+Configure Qdrant for archival memory and state persistence backends.
+
+### Python Configuration
+
+```python
+from asterix import Agent, StorageConfig
+
+agent = Agent(
+    storage=StorageConfig(
+        # Qdrant settings
+        qdrant_url="https://your-cluster.cloud.qdrant.io:6333",
+        qdrant_api_key="your-api-key",
+        qdrant_collection_name="asterix_memory",
+        vector_size=1536,
+        auto_create_collection=True,
+
+        # State persistence
+        state_backend="sqlite",  # or "json"
+        state_dir="./agent_states",
+        state_db="agents.db"
+    )
+)
+```
+
+### YAML Configuration
+
+```yaml
+storage:
+  # Qdrant Cloud
+  qdrant_url: "${QDRANT_URL}"
+  qdrant_api_key: "${QDRANT_API_KEY}"
+  qdrant_collection_name: "asterix_memory"
+  vector_size: 1536
+  qdrant_timeout: 30
+  auto_create_collection: true
+
+  # State persistence
+  state_backend: "json"
+  state_dir: "./agent_states"
+  state_db: "agents.db"
+```
+
+### State Backend Options
+
+- **`json`** - Simple file-based storage, one file per agent
+- **`sqlite`** - Database storage, better for multiple agents
+
+**See:** [Storage Backends](storage-backends.md) for detailed comparison.
+
+---
+
+## Embedding Configuration
+
+Configure embedding models for semantic search in Qdrant.
+
+### Python Configuration
+
+```python
+from asterix import Agent, EmbeddingConfig
+
+agent = Agent(
+    embedding_config=EmbeddingConfig(
+        provider="openai",
+        model="text-embedding-3-small",
+        dimensions=1536
+    )
+)
+```
+
+### YAML Configuration
+
+```yaml
+embedding:
+  provider: "openai"
+  model: "text-embedding-3-small"
+  dimensions: 1536
+  batch_size: 100
+```
+
+### Embedding Providers
+
+**OpenAI** (requires API key):
+```yaml
+embedding:
+  provider: "openai"
+  model: "text-embedding-3-small"
+  dimensions: 1536
+```
+
+**Sentence Transformers** (local, no API key):
+```yaml
+embedding:
+  provider: "sentence-transformers"
+  model: "all-MiniLM-L6-v2"
+  dimensions: 384
+```
+
+**Important:** `embedding.dimensions` must match `storage.vector_size`.
+
+---
+
+## Logging Configuration
+
+Asterix uses Python's standard logging module.
+
+### Console Logging
+
+```python
+import logging
+
+# Show all logs
+logging.basicConfig(level=logging.INFO)
+
+# Or just show errors
+logging.basicConfig(level=logging.ERROR)
+```
+
+### File Logging
+
+```python
+import logging
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    filename='asterix.log',
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+```
+
+### Fine-grained Control
+
+```python
+import logging
+
+# Control specific modules
+logging.getLogger('asterix.agent').setLevel(logging.DEBUG)
+logging.getLogger('asterix.core').setLevel(logging.WARNING)
+```
+
+### Environment Variable
+
+Set log level via environment:
+
+```bash
+ASTERIX_LOG_LEVEL=DEBUG
+```
+
+---
+
+## Memory Management Configuration
+
+Configure how agent memory is managed and archived.
+
+### Python Configuration
+
+```python
+from asterix import Agent, MemoryConfig
+
+agent = Agent(
+    memory_config=MemoryConfig(
+        eviction_strategy="summarize_and_archive",
+        summary_token_limit=220,
+        context_window_threshold=0.85,
+        extraction_enabled=True,
+        retrieval_k=6,
+        score_threshold=0.7
+    )
+)
+```
+
+### YAML Configuration
+
+```yaml
+memory:
+  eviction_strategy: "summarize_and_archive"
+  summary_token_limit: 220
+  context_window_threshold: 0.85
+  extraction_enabled: true
+  retrieval_k: 6
+  score_threshold: 0.7
+```
+
+### Configuration Options
+
+- **`eviction_strategy`** - How to handle full memory blocks
+  - `"summarize_and_archive"` - Summarize and store in Qdrant (default)
+  - `"truncate"` - Simply truncate (not recommended)
+
+- **`summary_token_limit`** - Target size for summarized blocks (default: 220)
+
+- **`context_window_threshold`** - Trigger extraction at % full (default: 0.85)
+
+- **`extraction_enabled`** - Enable automatic fact extraction (default: true)
+
+- **`retrieval_k`** - Number of memories to retrieve from Qdrant (default: 6)
+
+- **`score_threshold`** - Minimum similarity score for retrieval (default: 0.7)
+
+---
+
+## Complete Configuration Example
+
+**Python:**
+```python
+from asterix import Agent, BlockConfig, StorageConfig, MemoryConfig
+
+agent = Agent(
+    agent_id="production_agent",
+    model="openai/gpt-4o-mini",
+    temperature=0.1,
+    max_tokens=1000,
+    max_heartbeat_steps=10,
+
+    blocks={
+        "persona": BlockConfig(size=1000, priority=10),
+        "user": BlockConfig(size=1000, priority=5),
+        "task": BlockConfig(size=1500, priority=2),
+        "notes": BlockConfig(size=800, priority=3)
+    },
+
+    storage=StorageConfig(
+        qdrant_url="https://cluster.cloud.qdrant.io:6333",
+        qdrant_api_key="your-api-key",
+        state_backend="sqlite",
+        state_db="./agent_states/agents.db"
+    ),
+
+    memory_config=MemoryConfig(
+        eviction_strategy="summarize_and_archive",
+        context_window_threshold=0.85
+    )
+)
+```
+
+**YAML:** See [example_agent_config.yaml](../example_agent_config.yaml)
+
+---
+
+## See Also
+
+- [Storage Backends](storage-backends.md) - Persistence options
+- [Memory System](memory-system.md) - How memory works
+- [Examples Guide](examples-guide.md) - Configuration examples

--- a/docs/examples-guide.md
+++ b/docs/examples-guide.md
@@ -1,0 +1,504 @@
+# Examples Guide
+
+This guide walks through all the examples in the [`examples/`](../examples/) directory, explaining what each one demonstrates and how to use it.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Basic Chat](#basic-chat)
+- [Custom Tools](#custom-tools)
+- [Persistent Agent (JSON)](#persistent-agent-json)
+- [Persistent Agent (SQLite)](#persistent-agent-sqlite)
+- [Tool Documentation](#tool-documentation)
+- [CLI Agent](#cli-agent)
+- [YAML Configuration](#yaml-configuration)
+- [Advanced Examples](#advanced-examples)
+
+---
+
+## Getting Started
+
+### Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/adityasarade/Asterix.git
+cd Asterix
+
+# Install in editable mode
+pip install -e .
+
+# Set up environment variables (create .env file)
+# OPENAI_API_KEY=your-key
+# QDRANT_URL=your-qdrant-url
+# QDRANT_API_KEY=your-qdrant-key
+```
+
+### Running Examples
+
+```bash
+# Run any example
+python examples/basic_chat.py
+python examples/persistent_agent.py
+python examples/custom_tools.py
+```
+
+---
+
+## Basic Chat
+
+**File:** [`examples/basic_chat.py`](../examples/basic_chat.py)
+
+**Demonstrates:**
+- Creating a basic agent
+- Configuring memory blocks
+- Simple conversation
+- How agents use memory automatically
+
+### Key Concepts
+
+```python
+from asterix import Agent, BlockConfig
+
+# Create agent with custom memory blocks
+agent = Agent(
+    blocks={
+        "task": BlockConfig(size=1500, priority=1),
+        "notes": BlockConfig(size=1000, priority=2)
+    },
+    model="openai/gpt-4o-mini"
+)
+
+# Chat with your agent
+response = agent.chat("Hello! Remember that I prefer Python over JavaScript.")
+print(response)
+
+# Agent automatically updates its memory
+# Memory persists within the session
+```
+
+**What happens:**
+1. Agent receives your message
+2. Automatically determines if memory should be updated
+3. Uses `core_memory_append` to store "User prefers Python"
+4. Responds with acknowledgment
+
+**Run it:**
+```bash
+python examples/basic_chat.py
+```
+
+---
+
+## Custom Tools
+
+**File:** [`examples/custom_tools.py`](../examples/custom_tools.py)
+
+**Demonstrates:**
+- Registering custom tools
+- Parameter validation
+- Tool categories
+- Retry logic
+- Error handling
+
+### Key Concepts
+
+```python
+from asterix import Agent
+from asterix.tools.base import Tool, ParameterConstraint
+
+agent = Agent(...)
+
+# Simple tool
+@agent.tool(name="read_file", description="Read a file from disk")
+def read_file(filepath: str) -> str:
+    with open(filepath, 'r') as f:
+        return f.read()
+
+# Tool with validation
+@agent.tool(
+    name="create_user",
+    description="Create a new user account",
+    constraints={
+        "username": ParameterConstraint(
+            min_length=3,
+            max_length=20,
+            pattern=r'^[a-zA-Z0-9_]+$'
+        ),
+        "age": ParameterConstraint(min_value=13, max_value=120)
+    }
+)
+def create_user(username: str, age: int) -> str:
+    return f"Created user {username}, age {age}"
+
+# Tool with retry logic
+@agent.tool(
+    name="fetch_data",
+    description="Fetch data from API",
+    retry_on_error=True,
+    max_retries=3
+)
+def fetch_data(url: str) -> str:
+    response = requests.get(url)
+    return response.text
+
+# Now your agent can use these tools
+response = agent.chat("Create a user named 'john_doe' aged 25")
+```
+
+**Run it:**
+```bash
+python examples/custom_tools.py
+```
+
+---
+
+## Persistent Agent (JSON)
+
+**File:** [`examples/persistent_agent.py`](../examples/persistent_agent.py)
+
+**Demonstrates:**
+- Saving agent state to JSON
+- Loading previous state
+- Memory persistence across sessions
+- State directory management
+
+### Key Concepts
+
+```python
+from asterix import Agent, BlockConfig
+
+# Session 1: Create and save
+agent = Agent(
+    agent_id="my_assistant",
+    blocks={
+        "user_prefs": BlockConfig(size=800, priority=5),
+        "notes": BlockConfig(size=1200, priority=3)
+    },
+    model="openai/gpt-4o-mini"
+)
+
+agent.chat("Hi! I prefer Python over JavaScript.")
+agent.save_state()  # Saves to ./agent_states/my_assistant.json
+
+# Session 2: Load and continue
+agent = Agent.load_state("my_assistant")
+agent.chat("What language do I prefer?")  # Remembers!
+```
+
+**File structure:**
+```
+./agent_states/
+└── my_assistant.json
+```
+
+**Run it:**
+```bash
+python examples/persistent_agent.py
+```
+
+---
+
+## Persistent Agent (SQLite)
+
+**File:** [`examples/persistent_agent_sqlite.py`](../examples/persistent_agent_sqlite.py)
+
+**Demonstrates:**
+- Using SQLite backend
+- Managing multiple agents
+- Querying agent metadata
+- Production-ready persistence
+
+### Key Concepts
+
+```python
+from asterix import Agent, BlockConfig, StorageConfig
+
+# Create agent with SQLite backend
+agent = Agent(
+    agent_id="production_agent",
+    blocks={"task": BlockConfig(size=2000, priority=1)},
+    model="openai/gpt-4o-mini",
+    storage=StorageConfig(
+        state_backend="sqlite",
+        state_db="./agent_states/agents.db"
+    )
+)
+
+# Save to database
+agent.save_state()
+
+# Load from database
+agent = Agent.load_state(
+    "production_agent",
+    state_backend="sqlite",
+    state_db="./agent_states/agents.db"
+)
+
+# Query agent metadata
+from asterix.storage import SQLiteStateBackend
+
+backend = SQLiteStateBackend("./agent_states/agents.db")
+agents = backend.list_agents()
+info = backend.get_agent_info("production_agent")
+```
+
+**File structure:**
+```
+./agent_states/
+└── agents.db  # Single database for all agents
+```
+
+**Run it:**
+```bash
+python examples/persistent_agent_sqlite.py
+```
+
+---
+
+## Tool Documentation
+
+**File:** [`examples/tool_documentation.py`](../examples/tool_documentation.py)
+
+**Demonstrates:**
+- Auto-generating tool documentation
+- Exporting tool catalogs
+- Creating quick references
+- Different documentation formats
+
+### Key Concepts
+
+```python
+from asterix import Agent
+
+agent = Agent()
+
+# Single tool documentation
+docs = agent._tool_registry.generate_tool_docs("read_file", format="markdown")
+print(docs)
+
+# Complete registry documentation
+full_docs = agent._tool_registry.generate_registry_docs(
+    format="markdown",
+    group_by_category=True
+)
+
+# Save to file
+with open("TOOL_REFERENCE.md", "w") as f:
+    f.write(full_docs)
+
+# Export as JSON catalog
+catalog = agent._tool_registry.export_tool_catalog("json")
+
+# Quick reference guide
+quick_ref = agent._tool_registry.generate_quick_reference()
+```
+
+**Run it:**
+```bash
+python examples/tool_documentation.py
+```
+
+---
+
+## CLI Agent
+
+**File:** [`examples/cli_agent.py`](../examples/cli_agent.py)
+
+**Demonstrates:**
+- Full-featured CLI agent
+- File operation tools
+- Interactive conversation loop
+- State persistence between runs
+
+### Key Concepts
+
+```python
+from asterix import Agent, BlockConfig
+import os
+
+agent = Agent(
+    blocks={
+        "current_task": BlockConfig(size=2000, priority=1),
+        "file_context": BlockConfig(size=3000, priority=2)
+    },
+    model="openai/gpt-4o-mini"
+)
+
+@agent.tool(name="list_files")
+def list_files(directory: str = ".") -> str:
+    files = os.listdir(directory)
+    return "\n".join(files)
+
+@agent.tool(name="read_file")
+def read_file(filepath: str) -> str:
+    with open(filepath, 'r') as f:
+        return f.read()
+
+# Interactive loop
+while True:
+    user_input = input("You: ")
+    if user_input.lower() in ['exit', 'quit']:
+        break
+    response = agent.chat(user_input)
+    print(f"Agent: {response}")
+```
+
+**Run it:**
+```bash
+python examples/cli_agent.py
+```
+
+---
+
+## YAML Configuration
+
+**File:** [`examples/yaml_config.py`](../examples/yaml_config.py)
+
+**Demonstrates:**
+- Loading agent from YAML file
+- Configuration management
+- Environment variable substitution
+- Complex agent setup
+
+### Key Concepts
+
+```python
+from asterix import Agent
+
+# Load agent from YAML
+agent = Agent.from_yaml("agent_config.yaml")
+
+# YAML file structure
+"""
+agent_id: "my_agent"
+model: "openai/gpt-4o-mini"
+blocks:
+  task:
+    size: 1500
+    priority: 1
+storage:
+  qdrant_url: "${QDRANT_URL}"
+  state_backend: "json"
+"""
+```
+
+**See:** [example_agent_config.yaml](../example_agent_config.yaml) for full template.
+
+**Run it:**
+```bash
+python examples/yaml_config.py
+```
+
+---
+
+## Advanced Examples
+
+### Multi-Agent System
+
+```python
+# Orchestrator agent
+main_agent = Agent(
+    agent_id="orchestrator",
+    blocks={"plan": BlockConfig(size=1500)},
+    model="openai/gpt-4o-mini"
+)
+
+# Specialized agents
+code_reviewer = Agent(
+    agent_id="reviewer",
+    blocks={"code": BlockConfig(size=3000)},
+    model="openai/gpt-4o-mini"
+)
+
+data_analyst = Agent(
+    agent_id="analyst",
+    blocks={"data": BlockConfig(size=2000)},
+    model="openai/gpt-4o-mini"
+)
+
+# Coordination
+task = "Review auth.py for security issues"
+plan = main_agent.chat(f"Break down: {task}")
+review = code_reviewer.chat(f"Execute: {plan}")
+summary = main_agent.chat(f"Summarize: {review}")
+```
+
+### Custom Tool Class
+
+```python
+from asterix.tools.base import Tool, ToolCategory, ParameterConstraint
+
+class MyCustomTool(Tool):
+    def __init__(self):
+        super().__init__(
+            name="my_tool",
+            description="Custom tool with validation",
+            func=self.execute,
+            category=ToolCategory.CUSTOM,
+            constraints={
+                "param": ParameterConstraint(min_length=5)
+            },
+            retry_on_error=True,
+            max_retries=2
+        )
+
+    def execute(self, param: str) -> str:
+        # Your tool logic here
+        return f"Processed: {param}"
+
+# Register with agent
+agent.register_tool(MyCustomTool())
+```
+
+### Direct Memory Access
+
+```python
+# Get all memory blocks
+memory = agent.get_memory()
+print(memory["task"])
+
+# Update memory manually
+agent.update_memory("task", "New content")
+
+# Search archival memory
+tool_result = agent._tool_registry.execute_tool(
+    "archival_memory_search",
+    query="user preferences",
+    k=5
+)
+```
+
+---
+
+## Example Matrix
+
+| Example | Memory | Tools | Persistence | Config | Complexity |
+|---------|--------|-------|-------------|--------|------------|
+| basic_chat.py | ✅ | ❌ | ❌ | Python | ⭐ |
+| custom_tools.py | ✅ | ✅ | ❌ | Python | ⭐⭐ |
+| persistent_agent.py | ✅ | ❌ | ✅ JSON | Python | ⭐⭐ |
+| persistent_agent_sqlite.py | ✅ | ❌ | ✅ SQLite | Python | ⭐⭐ |
+| tool_documentation.py | ✅ | ✅ | ❌ | Python | ⭐⭐ |
+| cli_agent.py | ✅ | ✅ | ✅ | Python | ⭐⭐⭐ |
+| yaml_config.py | ✅ | ❌ | ✅ | YAML | ⭐⭐⭐ |
+
+---
+
+## Next Steps
+
+After running these examples:
+
+1. **Customize memory blocks** - Adjust sizes and priorities for your use case
+2. **Add custom tools** - Create tools specific to your application
+3. **Configure persistence** - Choose JSON or SQLite based on your needs
+4. **Explore advanced features** - Multi-agent systems, custom backends
+
+---
+
+## See Also
+
+- [Tool System](tool-system.md) - Creating and using tools
+- [Memory System](memory-system.md) - How memory works
+- [Storage Backends](storage-backends.md) - Persistence options
+- [Configuration](configuration.md) - All configuration options

--- a/docs/memory-system.md
+++ b/docs/memory-system.md
@@ -1,0 +1,347 @@
+# Memory System
+
+Asterix agents have a sophisticated memory system that allows them to remember, learn, and persist their knowledge across sessions. The memory system consists of memory blocks, archival storage, and conversation history.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Memory Blocks](#memory-blocks)
+- [Built-in Memory Tools](#built-in-memory-tools)
+- [Automatic Memory Management](#automatic-memory-management)
+- [Direct Memory Access](#direct-memory-access)
+- [Archival Memory](#archival-memory)
+- [Conversation Search](#conversation-search)
+
+---
+
+## Overview
+
+The Asterix memory system has three layers:
+
+1. **Memory Blocks** - Short-term, editable memory that agents can read and write
+2. **Archival Memory** - Long-term storage in Qdrant with semantic search
+3. **Conversation History** - Complete record of all interactions
+
+```
+┌─────────────────┐
+│  Memory Blocks  │  ← Short-term, editable (task, notes, etc.)
+└─────────────────┘
+        ↓ (when full)
+┌─────────────────┐
+│ Archival Memory │  ← Long-term, searchable (Qdrant)
+└─────────────────┘
+        +
+┌─────────────────┐
+│ Conversation    │  ← Full interaction history
+│    History      │
+└─────────────────┘
+```
+
+---
+
+## Memory Blocks
+
+Memory blocks are editable sections of the agent's short-term memory. Each block has:
+
+- **Name** - Identifier (e.g., "task", "notes", "user_prefs")
+- **Size** - Maximum tokens before eviction
+- **Priority** - Lower priority blocks are evicted first
+- **Description** - Purpose of the block
+
+### Configuring Memory Blocks
+
+```python
+from asterix import Agent, BlockConfig
+
+agent = Agent(
+    blocks={
+        "task": BlockConfig(
+            size=2000,          # Max tokens before eviction
+            priority=1,         # Lower = evicted first
+            description="Current task context"
+        ),
+        "user_prefs": BlockConfig(
+            size=500,
+            priority=5,         # High priority = rarely evicted
+            description="User preferences and settings"
+        ),
+        "notes": BlockConfig(
+            size=1000,
+            priority=2,
+            description="Important notes and reminders"
+        )
+    },
+    model="openai/gpt-4o-mini"
+)
+```
+
+### Memory Block Best Practices
+
+- **Task blocks** - Use for current work context (priority: 1-2)
+- **User preferences** - Keep user settings (priority: 4-5)
+- **Notes** - Temporary information (priority: 2-3)
+- **Context** - Relevant background info (priority: 2-3)
+
+---
+
+## Built-in Memory Tools
+
+Agents have 5 built-in tools for managing their memory:
+
+### 1. `core_memory_append`
+
+Add content to a memory block.
+
+```python
+# Agent automatically calls this when needed
+agent.chat("Remember that I prefer Python over JavaScript")
+
+# The agent uses: core_memory_append(block="user_prefs", content="User prefers Python over JavaScript")
+```
+
+### 2. `core_memory_replace`
+
+Replace content in a memory block.
+
+```python
+# Agent automatically calls this when needed
+agent.chat("Actually, I prefer TypeScript now")
+
+# The agent uses: core_memory_replace(
+#     block="user_prefs",
+#     old_content="User prefers Python",
+#     new_content="User prefers TypeScript"
+# )
+```
+
+### 3. `archival_memory_insert`
+
+Store information in Qdrant for long-term retrieval.
+
+```python
+# Agent stores important information for later
+# archival_memory_insert(content="Project X uses PostgreSQL database with 10M records")
+```
+
+### 4. `archival_memory_search`
+
+Search archived memories semantically.
+
+```python
+# Agent searches when it needs to recall something
+# archival_memory_search(query="database details", k=5)
+```
+
+### 5. `conversation_search`
+
+Search conversation history.
+
+```python
+# Agent searches past conversations
+# conversation_search(query="API key", k=3)
+```
+
+**Note:** These tools are called automatically by the agent. You don't need to invoke them manually.
+
+---
+
+## Automatic Memory Management
+
+When a memory block exceeds its token limit, Asterix automatically:
+
+1. **Summarizes** the content using the LLM
+2. **Archives** the full content in Qdrant
+3. **Replaces** the block with the summary
+4. **Makes it searchable** via `archival_memory_search`
+
+### Eviction Process
+
+```python
+# Block "task" has 2000 token limit
+# Current content: 1950 tokens
+# Agent tries to append 200 tokens → Exceeds limit!
+
+# Asterix automatically:
+# 1. Summarizes the 1950 token content → 500 tokens
+# 2. Archives original 1950 tokens in Qdrant
+# 3. Replaces block with 500 token summary
+# 4. Appends new 200 tokens
+# Result: Block now has 700 tokens
+```
+
+### Eviction Strategies
+
+You can configure how memory is managed:
+
+```python
+from asterix import Agent, MemoryConfig
+
+agent = Agent(
+    ...,
+    memory_config=MemoryConfig(
+        eviction_strategy="summarize_and_archive",  # Default
+        context_window_threshold=0.85  # Trigger at 85% full
+    )
+)
+```
+
+**Available strategies:**
+- `summarize_and_archive` - Summarize and store in Qdrant (default)
+- `archive_only` - Store in Qdrant without summarizing
+- `discard` - Remove oldest content (not recommended)
+
+---
+
+## Direct Memory Access
+
+You can manually access and update memory blocks:
+
+### Get Memory Contents
+
+```python
+# Get all memory blocks
+memory = agent.get_memory()
+print(memory["task"])
+print(memory["notes"])
+
+# Access specific block
+task_content = memory.get("task", "")
+```
+
+### Update Memory Manually
+
+```python
+# Update a memory block directly
+agent.update_memory("task", "New task: Build user authentication system")
+
+# Clear a memory block
+agent.update_memory("notes", "")
+```
+
+### Search Archival Memory
+
+```python
+# Manually search archived memories
+tool_result = agent._tool_registry.execute_tool(
+    "archival_memory_search",
+    query="user preferences",
+    k=5
+)
+print(tool_result)
+```
+
+---
+
+## Archival Memory
+
+Archival memory uses Qdrant for long-term, semantic storage.
+
+### Configuration
+
+Set up Qdrant in your `.env`:
+
+```bash
+QDRANT_URL=https://your-cluster.cloud.qdrant.io:6333
+QDRANT_API_KEY=your-qdrant-api-key
+```
+
+### How It Works
+
+1. **Storage** - Content is embedded using OpenAI embeddings
+2. **Indexing** - Vectors stored in Qdrant collection
+3. **Retrieval** - Semantic search finds relevant memories
+4. **Context** - Retrieved memories are added to agent context
+
+### Semantic Search
+
+Unlike keyword search, semantic search understands meaning:
+
+```python
+# Stored: "User prefers Python for data analysis"
+# Search: "programming language preference"
+# ✅ Finds the memory (semantically similar)
+
+# Search: "favorite food"
+# ❌ Doesn't find it (not semantically related)
+```
+
+---
+
+## Conversation Search
+
+Search through the agent's conversation history:
+
+```python
+# Agent automatically searches when needed
+# conversation_search(query="API key location", k=3)
+
+# Returns the 3 most relevant conversation turns
+```
+
+### Use Cases
+
+- Recall previous instructions
+- Find mentioned file paths
+- Remember user preferences from earlier in conversation
+- Locate specific information discussed before
+
+---
+
+## Memory System Architecture
+
+```
+┌──────────────────────────────────────┐
+│           Agent Context              │
+├──────────────────────────────────────┤
+│  Memory Blocks (Short-term)          │
+│  ┌────────┐ ┌────────┐ ┌──────────┐ │
+│  │  task  │ │ notes  │ │user_prefs││ │
+│  └────────┘ └────────┘ └──────────┘ │
+│                 ↓                    │
+│  When block is full: summarize       │
+│                 ↓                    │
+│  ┌────────────────────────────────┐ │
+│  │   Archival Memory (Qdrant)     │ │
+│  │   - Semantic search            │ │
+│  │   - Long-term storage          │ │
+│  └────────────────────────────────┘ │
+│                                      │
+│  ┌────────────────────────────────┐ │
+│  │   Conversation History         │ │
+│  │   - Full interaction record    │ │
+│  │   - Keyword search             │ │
+│  └────────────────────────────────┘ │
+└──────────────────────────────────────┘
+```
+
+---
+
+## Best Practices
+
+### Block Sizing
+
+- **Small blocks (500-1000 tokens)** - Frequently changing info
+- **Medium blocks (1000-2000 tokens)** - Current work context
+- **Large blocks (2000-3000 tokens)** - Comprehensive background
+
+### Priority Settings
+
+- **Priority 5** - Critical info (user preferences, requirements)
+- **Priority 3-4** - Important context
+- **Priority 1-2** - Temporary working memory
+
+### When to Use Each Layer
+
+| Memory Type | Use For | Lifespan |
+|-------------|---------|----------|
+| **Blocks** | Current task, active context | Until evicted |
+| **Archival** | Long-term facts, important info | Persistent |
+| **Conversation** | Recent interactions | Session |
+
+---
+
+## See Also
+
+- [Tool System](tool-system.md) - Memory tools documentation
+- [Storage Backends](storage-backends.md) - Persisting memory across sessions
+- [Configuration](configuration.md) - Memory configuration options

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -1,0 +1,479 @@
+# Storage Backends
+
+Asterix supports persistent agent state across sessions using multiple storage backends. This allows your agents to remember conversations, memory blocks, and context even after restarting your application.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [JSON Backend (Default)](#json-backend-default)
+- [SQLite Backend](#sqlite-backend)
+- [Choosing a Backend](#choosing-a-backend)
+- [Custom Backend](#custom-backend)
+- [Save and Load Operations](#save-and-load-operations)
+
+---
+
+## Overview
+
+Asterix persists the following agent state:
+
+- **Memory blocks** - All configured memory blocks and their contents
+- **Conversation history** - Complete message history
+- **Agent configuration** - Model, settings, and metadata
+- **Tool registry** - Custom tools and their configurations
+
+Two built-in backends are available:
+- **JSON** - Simple, human-readable files (default)
+- **SQLite** - Database storage for multiple agents
+
+---
+
+## JSON Backend (Default)
+
+Perfect for single agents, prototyping, and human-readable storage.
+
+### Basic Usage
+
+```python
+from asterix import Agent, BlockConfig
+
+# Create agent (JSON backend is default)
+agent = Agent(
+    agent_id="my_assistant",
+    blocks={
+        "user_prefs": BlockConfig(size=800, priority=5),
+        "notes": BlockConfig(size=1200, priority=3)
+    },
+    model="openai/gpt-4o-mini"
+)
+
+# Chat with agent
+agent.chat("Hi! I prefer Python over JavaScript.")
+
+# Save state to ./agent_states/my_assistant.json
+agent.save_state()
+
+# Later session - load previous state
+agent = Agent.load_state("my_assistant")
+agent.chat("What language do I prefer?")  # Remembers everything!
+```
+
+### Custom Directory
+
+```python
+from asterix import Agent, StorageConfig
+
+agent = Agent(
+    agent_id="my_assistant",
+    storage=StorageConfig(
+        state_backend="json",
+        state_dir="./custom_states"
+    )
+)
+
+# Saves to: ./custom_states/my_assistant.json
+agent.save_state()
+```
+
+### JSON File Structure
+
+```json
+{
+  "agent_id": "my_assistant",
+  "model": "openai/gpt-4o-mini",
+  "blocks": {
+    "task": {
+      "content": "Current task content...",
+      "size": 1500,
+      "priority": 1
+    }
+  },
+  "messages": [
+    {"role": "user", "content": "Hello"},
+    {"role": "assistant", "content": "Hi there!"}
+  ],
+  "metadata": {
+    "created_at": "2025-01-15T10:30:00",
+    "last_updated": "2025-01-15T14:25:00"
+  }
+}
+```
+
+### Advantages
+
+- ✅ Human-readable
+- ✅ Easy to inspect and debug
+- ✅ Simple file-based storage
+- ✅ Git-friendly (can version control)
+- ✅ No database setup required
+
+### Limitations
+
+- ❌ No atomic updates
+- ❌ No querying capabilities
+- ❌ One file per agent (can clutter directories)
+- ❌ Not ideal for 10+ agents
+
+---
+
+## SQLite Backend
+
+Better for production, multiple agents, and querying capabilities.
+
+### Basic Usage
+
+```python
+from asterix import Agent, BlockConfig, StorageConfig
+
+# Create agent with SQLite backend
+agent = Agent(
+    agent_id="production_agent",
+    blocks={"task": BlockConfig(size=2000, priority=1)},
+    model="openai/gpt-4o-mini",
+    storage=StorageConfig(
+        state_backend="sqlite",
+        state_db="./agent_states/agents.db"
+    )
+)
+
+# Save to SQLite database
+agent.save_state()
+
+# Load from SQLite
+agent = Agent.load_state(
+    "production_agent",
+    state_backend="sqlite",
+    state_db="./agent_states/agents.db"
+)
+```
+
+### Advanced Features
+
+Query agent metadata without loading full state:
+
+```python
+from asterix.storage import SQLiteStateBackend
+
+backend = SQLiteStateBackend("./agent_states/agents.db")
+
+# List all agents
+agents = backend.list_agents()
+print(agents)  # ['agent1', 'agent2', 'agent3']
+
+# Get agent metadata
+info = backend.get_agent_info("agent1")
+print(info)
+
+# Output:
+# {
+#   'agent_id': 'agent1',
+#   'model': 'openai/gpt-4o-mini',
+#   'block_count': 3,
+#   'message_count': 42,
+#   'created_at': '2025-01-15T10:30:00',
+#   'last_updated': '2025-01-15T14:25:00'
+# }
+
+# List all agents with metadata
+all_agents = backend.list_all_info(limit=10)
+for agent in all_agents:
+    print(f"{agent['agent_id']}: {agent['message_count']} messages")
+```
+
+### Managing Multiple Agents
+
+```python
+from asterix import Agent, StorageConfig
+
+# Shared database for all agents
+db_path = "./agent_states/agents.db"
+
+# Create multiple agents
+agent1 = Agent(
+    agent_id="customer_support",
+    storage=StorageConfig(state_backend="sqlite", state_db=db_path)
+)
+
+agent2 = Agent(
+    agent_id="code_reviewer",
+    storage=StorageConfig(state_backend="sqlite", state_db=db_path)
+)
+
+agent3 = Agent(
+    agent_id="data_analyst",
+    storage=StorageConfig(state_backend="sqlite", state_db=db_path)
+)
+
+# All agents share one database file
+agent1.save_state()
+agent2.save_state()
+agent3.save_state()
+```
+
+### Database Schema
+
+SQLite backend creates the following tables:
+
+```sql
+CREATE TABLE agents (
+    agent_id TEXT PRIMARY KEY,
+    model TEXT NOT NULL,
+    state_json TEXT NOT NULL,
+    created_at TIMESTAMP,
+    last_updated TIMESTAMP
+);
+
+CREATE INDEX idx_last_updated ON agents(last_updated);
+```
+
+### Advantages
+
+- ✅ Atomic updates (transaction-safe)
+- ✅ Query capabilities
+- ✅ Single database file for all agents
+- ✅ Better for 10+ agents
+- ✅ Metadata queries without full load
+- ✅ Production-ready
+
+### Limitations
+
+- ❌ Not human-readable
+- ❌ Requires SQLite (usually available)
+- ❌ Slightly more complex setup
+
+---
+
+## Choosing a Backend
+
+| Feature | JSON | SQLite |
+|---------|------|--------|
+| **Best for** | 1-10 agents, prototyping | 10+ agents, production |
+| **Performance** | Fast for single agent | Fast for many agents |
+| **Querying** | ❌ | ✅ |
+| **Human-readable** | ✅ | ❌ |
+| **Atomic updates** | ❌ | ✅ |
+| **File structure** | One file per agent | Single database file |
+| **Setup complexity** | None | Minimal |
+| **Git-friendly** | ✅ | ❌ |
+
+### Decision Guide
+
+**Choose JSON if:**
+- You have 1-10 agents
+- You're prototyping
+- You want to inspect state manually
+- You want version control on agent state
+
+**Choose SQLite if:**
+- You have 10+ agents
+- You're in production
+- You need to query agent metadata
+- You want atomic updates
+- You need multi-agent management
+
+---
+
+## Custom Backend
+
+Implement your own storage backend by following this interface:
+
+```python
+class CustomBackend:
+    """Custom storage backend interface"""
+
+    def save(self, agent_id: str, state_dict: dict) -> None:
+        """Save agent state"""
+        # Your implementation here
+        pass
+
+    def load(self, agent_id: str) -> dict:
+        """Load agent state"""
+        # Your implementation here
+        pass
+
+    def exists(self, agent_id: str) -> bool:
+        """Check if agent exists"""
+        # Your implementation here
+        pass
+
+    def delete(self, agent_id: str) -> None:
+        """Delete agent state"""
+        # Your implementation here
+        pass
+
+# Use custom backend
+agent = Agent(
+    agent_id="my_agent",
+    storage=StorageConfig(state_backend=CustomBackend())
+)
+```
+
+### Redis Backend Example
+
+```python
+import redis
+import json
+
+class RedisBackend:
+    def __init__(self, host='localhost', port=6379, db=0):
+        self.redis = redis.Redis(host=host, port=port, db=db)
+
+    def save(self, agent_id: str, state_dict: dict) -> None:
+        key = f"agent:{agent_id}"
+        self.redis.set(key, json.dumps(state_dict))
+
+    def load(self, agent_id: str) -> dict:
+        key = f"agent:{agent_id}"
+        data = self.redis.get(key)
+        return json.loads(data) if data else None
+
+    def exists(self, agent_id: str) -> bool:
+        key = f"agent:{agent_id}"
+        return self.redis.exists(key)
+
+    def delete(self, agent_id: str) -> None:
+        key = f"agent:{agent_id}"
+        self.redis.delete(key)
+
+# Use Redis backend
+agent = Agent(
+    agent_id="redis_agent",
+    storage=StorageConfig(state_backend=RedisBackend())
+)
+```
+
+### PostgreSQL Backend Example
+
+```python
+import psycopg2
+import json
+
+class PostgreSQLBackend:
+    def __init__(self, connection_string: str):
+        self.conn = psycopg2.connect(connection_string)
+        self._create_table()
+
+    def _create_table(self):
+        with self.conn.cursor() as cur:
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS agents (
+                    agent_id TEXT PRIMARY KEY,
+                    state_json JSONB NOT NULL,
+                    created_at TIMESTAMP DEFAULT NOW(),
+                    updated_at TIMESTAMP DEFAULT NOW()
+                )
+            """)
+            self.conn.commit()
+
+    def save(self, agent_id: str, state_dict: dict) -> None:
+        with self.conn.cursor() as cur:
+            cur.execute("""
+                INSERT INTO agents (agent_id, state_json)
+                VALUES (%s, %s)
+                ON CONFLICT (agent_id)
+                DO UPDATE SET state_json = %s, updated_at = NOW()
+            """, (agent_id, json.dumps(state_dict), json.dumps(state_dict)))
+            self.conn.commit()
+
+    def load(self, agent_id: str) -> dict:
+        with self.conn.cursor() as cur:
+            cur.execute("SELECT state_json FROM agents WHERE agent_id = %s", (agent_id,))
+            result = cur.fetchone()
+            return result[0] if result else None
+
+    def exists(self, agent_id: str) -> bool:
+        with self.conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM agents WHERE agent_id = %s", (agent_id,))
+            return cur.fetchone() is not None
+
+    def delete(self, agent_id: str) -> None:
+        with self.conn.cursor() as cur:
+            cur.execute("DELETE FROM agents WHERE agent_id = %s", (agent_id,))
+            self.conn.commit()
+```
+
+---
+
+## Save and Load Operations
+
+### Saving State
+
+```python
+# Automatic save (recommended)
+agent.save_state()  # Uses configured backend
+
+# With explicit path (JSON only)
+agent.save_state(filepath="./backups/agent_backup.json")
+```
+
+### Loading State
+
+```python
+# Load from default backend
+agent = Agent.load_state("agent_id")
+
+# Load from specific backend
+agent = Agent.load_state(
+    "agent_id",
+    state_backend="sqlite",
+    state_db="./agent_states/agents.db"
+)
+
+# Load from JSON file
+agent = Agent.load_state("agent_id", state_backend="json", state_dir="./custom_states")
+```
+
+### Checking if State Exists
+
+```python
+from asterix import Agent
+
+# Check if agent state exists
+if Agent.state_exists("my_agent", state_backend="json"):
+    agent = Agent.load_state("my_agent")
+else:
+    agent = Agent(agent_id="my_agent")
+```
+
+### Deleting State
+
+```python
+# JSON backend - delete file
+import os
+os.remove("./agent_states/my_agent.json")
+
+# SQLite backend - delete from database
+from asterix.storage import SQLiteStateBackend
+backend = SQLiteStateBackend("./agent_states/agents.db")
+backend.delete("my_agent")
+```
+
+---
+
+## Environment Configuration
+
+Configure storage via environment variables:
+
+```bash
+# .env file
+ASTERIX_STATE_DIR=./agent_states
+ASTERIX_STATE_BACKEND=sqlite  # or "json"
+ASTERIX_STATE_DB=./agent_states/agents.db  # for SQLite
+```
+
+```python
+from asterix import Agent
+import os
+
+# Uses environment variables
+agent = Agent(agent_id="my_agent")
+agent.save_state()  # Uses ASTERIX_STATE_DIR and ASTERIX_STATE_BACKEND
+```
+
+---
+
+## See Also
+
+- [Configuration](configuration.md) - Environment and YAML configuration
+- [Memory System](memory-system.md) - What gets persisted
+- [Examples Guide](examples-guide.md) - Complete examples with persistence

--- a/docs/tool-system.md
+++ b/docs/tool-system.md
@@ -1,0 +1,328 @@
+# Tool System
+
+Asterix provides a powerful tool system that allows agents to interact with external functionality. Tools can be custom functions you define, or built-in memory management tools.
+
+## Table of Contents
+
+- [Built-in Memory Tools](#built-in-memory-tools)
+- [Creating Custom Tools](#creating-custom-tools)
+- [Parameter Validation](#parameter-validation)
+- [Tool Categories](#tool-categories)
+- [Retry Logic](#retry-logic)
+- [Error Handling](#error-handling)
+- [Auto-Documentation](#auto-documentation)
+- [Tool Discovery](#tool-discovery)
+- [Advanced Tool Development](#advanced-tool-development)
+
+---
+
+## Built-in Memory Tools
+
+Agents have 5 built-in tools for managing their memory:
+
+| Tool | Category | Description |
+|------|----------|-------------|
+| `core_memory_append` | memory | Add content to a memory block |
+| `core_memory_replace` | memory | Replace content in a memory block |
+| `archival_memory_insert` | memory | Store information in Qdrant for long-term retrieval |
+| `archival_memory_search` | memory | Search archived memories semantically |
+| `conversation_search` | memory | Search conversation history |
+
+These tools are called automatically by the agent when needed.
+
+---
+
+## Creating Custom Tools
+
+Register custom tools using the decorator pattern:
+
+```python
+from asterix import Agent
+
+agent = Agent(...)
+
+@agent.tool(
+    name="execute_shell",
+    description="Run a shell command and return output"
+)
+def execute_shell(command: str) -> str:
+    import subprocess
+    result = subprocess.run(command, shell=True, capture_output=True, text=True)
+    return result.stdout
+
+@agent.tool(name="search_web")
+def search_web(query: str) -> str:
+    # Your web search implementation
+    return "Search results..."
+
+# Agent can now use these tools
+response = agent.chat("List all Python files in the current directory")
+```
+
+---
+
+## Parameter Validation
+
+Tools can define validation constraints for their parameters:
+
+```python
+from asterix.tools.base import Tool, ParameterConstraint
+
+@agent.tool(
+    name="create_user",
+    description="Create a new user account",
+    constraints={
+        "username": ParameterConstraint(
+            min_length=3,
+            max_length=20,
+            pattern=r'^[a-zA-Z0-9_]+$'
+        ),
+        "age": ParameterConstraint(
+            min_value=13,
+            max_value=120
+        )
+    }
+)
+def create_user(username: str, age: int) -> str:
+    return f"Created user {username}, age {age}"
+```
+
+### Available Constraints
+
+- **`min_length`** / **`max_length`** - String length validation
+- **`min_value`** / **`max_value`** - Numeric range validation
+- **`pattern`** - Regex pattern matching
+- **`allowed_values`** - Whitelist of acceptable values
+
+---
+
+## Tool Categories
+
+Organize tools by category for better discovery:
+
+```python
+from asterix.tools.base import ToolCategory
+
+# Tools are automatically categorized
+memory_tools = agent._tool_registry.get_by_category(ToolCategory.MEMORY)
+file_tools = agent._tool_registry.get_by_category(ToolCategory.FILE_OPS)
+
+# List all categories with counts
+categories = agent._tool_registry.list_categories()
+print(categories)  # {"memory": 5, "file_operations": 3, "custom": 2}
+```
+
+### Available Categories
+
+- `ToolCategory.MEMORY` - Memory management tools
+- `ToolCategory.FILE_OPS` - File operations
+- `ToolCategory.WEB` - Web/API operations
+- `ToolCategory.DATA` - Data processing
+- `ToolCategory.CUSTOM` - User-defined tools
+
+---
+
+## Retry Logic
+
+Enable automatic retries for transient failures:
+
+```python
+from asterix.tools.base import Tool
+
+@agent.tool(
+    name="fetch_data",
+    description="Fetch data from API",
+    retry_on_error=True,
+    max_retries=3
+)
+def fetch_data(url: str) -> str:
+    # Will retry up to 3 times with exponential backoff
+    response = requests.get(url)
+    return response.text
+```
+
+**Retry behavior:**
+- Exponential backoff between retries
+- Only retries on transient errors (network, timeouts)
+- Preserves original error on final failure
+
+---
+
+## Error Handling
+
+Rich error context and helpful suggestions:
+
+```python
+from asterix.tools.base import ToolNotFoundError, ToolExecutionError, ToolValidationError
+
+try:
+    # Typo in tool name
+    agent._tool_registry.execute_tool("read_fle", filepath="test.txt")
+except ToolNotFoundError as e:
+    print(e)  # Suggests similar tool names
+
+try:
+    # Invalid parameter
+    agent._tool_registry.execute_tool("create_user", username="ab", age=5)
+except ToolValidationError as e:
+    print(e)  # Shows validation constraints and provided value
+```
+
+### Validation Errors
+
+Parameter validation errors include helpful context:
+
+```
+Tool 'create_user' parameter 'username' validation failed:
+ username length must be >= 3, got 2
+ Provided value: ab
+```
+
+### Error Context
+
+All tool errors include rich metadata for debugging:
+
+```python
+try:
+    result = tool.execute(invalid_param="value")
+except Exception as e:
+    # Error metadata includes:
+    # - Tool name
+    # - Exception type
+    # - Parameters provided
+    # - Retry attempts (if applicable)
+    # - Full stack trace in logs
+    pass
+```
+
+---
+
+## Auto-Documentation
+
+Generate documentation for your tools:
+
+```python
+# Single tool documentation
+docs = agent._tool_registry.generate_tool_docs("read_file", format="markdown")
+print(docs)
+
+# Complete registry documentation
+full_docs = agent._tool_registry.generate_registry_docs(
+    format="markdown",
+    group_by_category=True
+)
+
+# Save to file
+with open("TOOL_REFERENCE.md", "w") as f:
+    f.write(full_docs)
+
+# Export as JSON catalog
+catalog = agent._tool_registry.export_tool_catalog("json")
+
+# Quick reference guide
+quick_ref = agent._tool_registry.generate_quick_reference()
+```
+
+### Documentation Formats
+
+- **Markdown** - Human-readable docs
+- **JSON** - Machine-parseable catalog
+- **YAML** - Configuration-style docs
+
+---
+
+## Tool Discovery
+
+Find tools by various criteria:
+
+```python
+# Filter by category
+memory_tools = agent._tool_registry.filter_tools(category=ToolCategory.MEMORY)
+
+# Filter by name pattern
+search_tools = agent._tool_registry.filter_tools(name_pattern="search")
+
+# Filter by capabilities
+validated_tools = agent._tool_registry.filter_tools(has_validation=True)
+retry_tools = agent._tool_registry.filter_tools(has_retry=True)
+
+# Get detailed tool info
+info = agent._tool_registry.get_tool_info("core_memory_append")
+print(f"Category: {info['category']}")
+print(f"Constraints: {info['constraints']}")
+print(f"Examples: {info['examples']}")
+```
+
+---
+
+## Advanced Tool Development
+
+Creating custom tools with full features:
+
+```python
+from asterix.tools.base import Tool, ToolCategory, ParameterConstraint
+
+class MyCustomTool(Tool):
+    def __init__(self):
+        super().__init__(
+            name="my_tool",
+            description="Custom tool with validation",
+            func=self.execute,
+            category=ToolCategory.CUSTOM,
+            constraints={
+                "param": ParameterConstraint(min_length=5)
+            },
+            retry_on_error=True,
+            max_retries=2
+        )
+
+    def execute(self, param: str) -> str:
+        # Your tool logic here
+        return f"Processed: {param}"
+
+# Register with agent
+agent.register_tool(MyCustomTool())
+```
+
+### Tool Configuration Options
+
+When registering tools, you can configure:
+
+```python
+from asterix.tools.base import Tool, ToolCategory, ParameterConstraint
+
+@agent.tool(
+    name="advanced_tool",
+    description="Tool with full configuration",
+    category=ToolCategory.DATA,
+    constraints={
+        "query": ParameterConstraint(min_length=1, max_length=500)
+    },
+    examples=[
+        "advanced_tool(query='search term')",
+        "advanced_tool(query='another example')"
+    ],
+    retry_on_error=True,
+    max_retries=3
+)
+def advanced_tool(query: str) -> str:
+    return f"Processed: {query}"
+```
+
+### Tool System Features
+
+- **Automatic Schema Generation** - Type hints → OpenAI function schemas
+- **Parameter Validation** - Min/max values, lengths, patterns, allowed values
+- **Category Organization** - Group tools by purpose (memory, file_ops, web, etc.)
+- **Retry Logic** - Automatic retries with exponential backoff
+- **Error Recovery** - Smart error messages with hints and suggestions
+- **Auto-Documentation** - Generate markdown/JSON/YAML docs from metadata
+- **Tool Discovery** - Filter and search tools by name, category, capabilities
+
+---
+
+## See Also
+
+- [Memory System](memory-system.md) - How memory tools work
+- [API Reference](api-reference.md) - Complete tool reference
+- [Examples Guide](examples-guide.md) - Tool usage examples


### PR DESCRIPTION
- Shorten README from 832 to 196 lines (76% reduction)
- Create /docs folder with organized documentation:
  - api-reference.md: Complete API documentation
  - configuration.md: Environment, YAML, and Python config
  - examples-guide.md: Detailed walkthrough of examples
  - memory-system.md: Memory blocks, archival, and search
  - storage-backends.md: JSON, SQLite, and custom backends
  - tool-system.md: Tool creation, validation, and features
- Update README with clear navigation to all documentation
- Fix broken links in Support section
- Remove docs/ from .gitignore to track documentation
- Improve discoverability with quick links and organized sections